### PR TITLE
lock some dependencies

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -5,9 +5,10 @@
   "dependencies": {
     "@reach/router": "^1.2.1",
     "chart.js": "^2.7.3",
-    "react": "^16.7.0-alpha.0",
+    "react": "16.7.0-alpha.0",
     "react-cache": "^2.0.0-alpha.1",
-    "react-dom": "^16.7.0-alpha.0",
+    "react-dom": "16.7.0-alpha.0",
+    "scheduler": "0.11.0-alpha.0",
     "react-scripts": "2.1.1"
   },
   "scripts": {


### PR DESCRIPTION
React has released 16.8.x, which do not exclude _Concurrent Mode_。
To keep the demo running, we should lock some package such as *react-dom*, *scheduler*